### PR TITLE
handling reshape of history data

### DIFF
--- a/app/routes/devices.$id.hardware.$hardware_name.history.tsx
+++ b/app/routes/devices.$id.hardware.$hardware_name.history.tsx
@@ -78,15 +78,22 @@ export default function Hardware() {
     );
   }
   const hardwareHistory = data[hardware_name];
-  const allHardwareVials = Object.keys(hardwareHistory[0].data);
   const allHardwareVialsProperties = Object.keys(
-    hardwareHistory[0].data[allHardwareVials[0]],
+    hardwareHistory[0].data,
   ).filter((property) => excludedProperties.includes(property) === false);
 
   let selectedProperties: string[] = allHardwareVialsProperties;
-  let selectedVials: string[] = allHardwareVials;
+  let selectedVials: string[] = [];
   if (searchParams.has("vials")) {
     selectedVials = [...new Set(searchParams.get("vials")?.split(",") ?? [])];
+  } else {
+    Array.from(
+      new Set(hardwareHistory.map((entry) => entry.vial?.toString())),
+    ).forEach((vial) => {
+      if (vial) {
+        selectedVials.push(vial);
+      }
+    });
   }
   if (searchParams.has("properties")) {
     selectedProperties = [

--- a/openapi.json
+++ b/openapi.json
@@ -616,7 +616,12 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Body_history"
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/Body_history"
+                  }
+                ],
+                "title": "Body"
               }
             }
           }
@@ -782,6 +787,23 @@
     "schemas": {
       "Body_history": {
         "properties": {
+          "kinds": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kinds",
+            "default": [
+              "sensor"
+            ]
+          },
           "vials": {
             "anyOf": [
               {
@@ -905,6 +927,26 @@
           "interval": {
             "type": "integer",
             "title": "Interval"
+          },
+          "raise_loop_exceptions": {
+            "type": "boolean",
+            "title": "Raise Loop Exceptions"
+          },
+          "abort_on_control_errors": {
+            "type": "boolean",
+            "title": "Abort On Control Errors"
+          },
+          "abort_on_commit_errors": {
+            "type": "boolean",
+            "title": "Abort On Commit Errors"
+          },
+          "skip_control_on_read_failure": {
+            "type": "boolean",
+            "title": "Skip Control On Read Failure"
+          },
+          "log_level": {
+            "type": "integer",
+            "title": "Log Level"
           }
         },
         "type": "object",
@@ -917,7 +959,12 @@
           "serial",
           "history",
           "enable_control",
-          "interval"
+          "interval",
+          "raise_loop_exceptions",
+          "abort_on_control_errors",
+          "abort_on_commit_errors",
+          "skip_control_on_read_failure",
+          "log_level"
         ],
         "title": "EvolverConfigWithoutDefaults"
       },
@@ -940,6 +987,21 @@
             "type": "number",
             "title": "Timestamp"
           },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "vial": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vial"
+          },
           "data": {
             "title": "Data"
           }
@@ -947,6 +1009,8 @@
         "type": "object",
         "required": [
           "timestamp",
+          "kind",
+          "vial",
           "data"
         ],
         "title": "HistoricDatum"


### PR DESCRIPTION
https://github.com/ssec-jhu/evolver-ng/pull/218 changed the shape of history data a bit, and I forgot to make sure @imaitland reviewed that one prior to merge, so making an attempt at doing the corresponding UI for it.

**Note:** I couldn't figure out some typing problems, but the rendering looks as expected (with some seeming gaps due to rounding and points on bordering seconds)

![image](https://github.com/user-attachments/assets/9105f757-0788-4b91-946f-52ee1170d7d7)


**Note:** Basically, the change in https://github.com/ssec-jhu/evolver-ng/pull/218 makes vial a first-class-citizen of history, which makes:

```js
[
  { time: ..., data: { vial_1: { property_a: ..., ...}, vial_2: ...}}, 
  {...}
]
```
into
```js
[
  {time: ..., vial: vial_1, data: {property_a: ..., ...}, 
  {time: ..., vial: vial_2, data: {property_a: ..., ...},
  {...}
]
```